### PR TITLE
Adding shebang at beginning of python script in order to make it executable

### DIFF
--- a/provisioning-helper.py
+++ b/provisioning-helper.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import requests
 import getpass
 import json


### PR DESCRIPTION
Now the script can be invoked both as
```bash
python3 provisioning-helper.py ...
```
and
```bash
./provisioning-helper.py ...
```

This fixes #4.